### PR TITLE
Basic tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 bootloader = "0.9.23"
 volatile = "0.2.6"
 spin = "0.5.2"
+x86_64 = "0.14.2" # Use x86 abstractions for in/out instructions
 
 [dependencies.lazy_static]
 version = "1.0"
@@ -19,3 +20,7 @@ features = ["spin_no_std"]
 
 [profile.release]
 panic = "abort"
+
+[package.metadata.bootimage]
+test-args = ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"] # Append to QEMU args (allow quitting)
+test-success-exit-code = 33 # (0x10 << 1) | 1 : map exit code to 0 so success shuts down qemu without failing cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ test-args = [
     "-display", "none" # Don't show the window while testing
 ] # Append to QEMU args (allow quitting and redirection of test logs to host stdio)
 test-success-exit-code = 33 # (0x10 << 1) | 1 : map exit code to 0 so success shuts down qemu without failing cargo test
+test-timeout = 60 # (in seconds) : here we want to make bootimage wait through endless loops for 1 minute before terminating

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ spin = "0.5.2"
 version = "1.0"
 features = ["spin_no_std"]
 
-[profile.dev]
-panic = "abort"
+# [profile.dev]
+# panic = "abort" - we need to comment this out for running tests to avovid duplicate lang item errors
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ panic = "abort"
 
 [package.metadata.bootimage]
 test-args = [
-    "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04", "-serial", "stdio"
+    "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04", "-serial", "stdio",
+    "-display", "none" # Don't show the window while testing
 ] # Append to QEMU args (allow quitting and redirection of test logs to host stdio)
 test-success-exit-code = 33 # (0x10 << 1) | 1 : map exit code to 0 so success shuts down qemu without failing cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ test-args = [
 ] # Append to QEMU args (allow quitting and redirection of test logs to host stdio)
 test-success-exit-code = 33 # (0x10 << 1) | 1 : map exit code to 0 so success shuts down qemu without failing cargo test
 test-timeout = 60 # (in seconds) : here we want to make bootimage wait through endless loops for 1 minute before terminating
+
+[[test]]
+name = "should_panic"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ bootloader = "0.9.23"
 volatile = "0.2.6"
 spin = "0.5.2"
 x86_64 = "0.14.2" # Use x86 abstractions for in/out instructions
+uart_16550 = "0.2.0"
 
 [dependencies.lazy_static]
 version = "1.0"
@@ -22,5 +23,7 @@ features = ["spin_no_std"]
 panic = "abort"
 
 [package.metadata.bootimage]
-test-args = ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"] # Append to QEMU args (allow quitting)
+test-args = [
+    "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04", "-serial", "stdio"
+] # Append to QEMU args (allow quitting and redirection of test logs to host stdio)
 test-success-exit-code = 33 # (0x10 << 1) | 1 : map exit code to 0 so success shuts down qemu without failing cargo test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,78 @@
+#![no_std]
+
+#![cfg_attr(test, no_main)]
+#![feature(custom_test_frameworks)]
+#![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"] // Make sure our test harness' entry point is called test_main to avoid passing over testing
+
+
+
+pub mod vga_buffer;
+pub mod serial;
+
+use core::panic::PanicInfo;
+
+/// Provide serial test printout statements to a test function
+pub trait Testable {
+    fn run(&self) -> ();
+}
+
+/// Wrap serial test printout statements around a test function callable Fn()
+impl<T> Testable for T
+where
+    T: Fn(),
+{
+    fn run(&self) {
+        serial_print!("{}...\t", core::any::type_name::<T>());
+        self();
+        serial_println!("[ok]");
+    }
+}
+
+
+pub fn test_runner(tests: &[&dyn Testable]) {
+    serial_println!("Running {} tests", tests.len());
+    for test in tests {
+        test.run(); // Provide logging via serial
+    }
+    // Now that we've run all our tests, quit from QEMU
+    exit_qemu(QemuExitCode::Success);
+}
+
+
+pub fn test_panic_handler(info: &PanicInfo) -> ! {
+    serial_println!("[failed]\n");
+    serial_println!("Error: {}\n", info);
+    exit_qemu(QemuExitCode::Failure);
+    loop {} // Kept as compiler doesn't know we're causing a program exit
+}
+
+#[cfg(test)] // Entry point for `cargo test`
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    test_main();
+    loop {}
+}
+
+#[cfg(test)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    test_panic_handler(info)
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum QemuExitCode {
+    Success = 0x10,
+    Failure = 0x11,
+}
+
+pub fn exit_qemu(exit_code: QemuExitCode) {
+    use x86_64::instructions::port::Port;
+
+    unsafe {
+        let mut port = Port::new(0xf4);
+        port.write(exit_code as u32);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 
 #[cfg(test)]
 fn test_runner(tests: &[&dyn Fn()]) {
-    println!("Running {} tests", tests.len());
+    serial_println!("Running {} tests", tests.len());
     for test in tests {
         test();
     }
@@ -18,9 +18,9 @@ fn test_runner(tests: &[&dyn Fn()]) {
 
 #[test_case]
 fn trivial_assertion() {
-    print!("testing harness... ");
+    serial_print!("testing harness... ");
     assert_eq!(1, 1);
-    println!("[ok]");
+    serial_println!("[ok]");
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,6 +40,7 @@ pub fn exit_qemu(exit_code: QemuExitCode) {
 }
 
 mod vga_buffer;
+mod serial;
 
 use core::panic::PanicInfo;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ fn test_runner(tests: &[&dyn Fn()]) {
     for test in tests {
         test();
     }
+    // Now that we've run all our tests, quit from QEMU
+    exit_qemu(QemuExitCode::Success);
 }
 
 #[test_case]
@@ -19,6 +21,22 @@ fn trivial_assertion() {
     print!("testing harness... ");
     assert_eq!(1, 1);
     println!("[ok]");
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum QemuExitCode {
+    Success = 0x10,
+    Failure = 0x11,
+}
+
+pub fn exit_qemu(exit_code: QemuExitCode) {
+    use x86_64::instructions::port::Port;
+
+    unsafe {
+        let mut port = Port::new(0xf4);
+        port.write(exit_code as u32);
+    }
 }
 
 mod vga_buffer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,18 @@
 #![no_std]
 #![no_main]
 
+
+#![feature(custom_test_frameworks)]
+#![test_runner(crate::test_runner)]
+
+#[cfg(test)]
+fn test_runner(tests: &[&dyn Fn()]) {
+    println!("Running {} tests", tests.len());
+    for test in tests {
+        test();
+    }
+}
+
 mod vga_buffer;
 
 use core::panic::PanicInfo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"] // Make sure our test harness' entry point is called test_main to avoid passing over testing
 
 #[cfg(test)]
 fn test_runner(tests: &[&dyn Fn()]) {
@@ -13,6 +14,13 @@ fn test_runner(tests: &[&dyn Fn()]) {
     }
 }
 
+#[test_case]
+fn trivial_assertion() {
+    print!("testing harness... ");
+    assert_eq!(1, 1);
+    println!("[ok]");
+}
+
 mod vga_buffer;
 
 use core::panic::PanicInfo;
@@ -20,7 +28,10 @@ use core::panic::PanicInfo;
 #[no_mangle]
 pub extern "C" fn _start() -> !{
     println!("Hello World, this is {}: a basic operating system for learning.", "NUGGET");
-    panic!("Oops! Something went terribly wrong. Please restart the machine.");
+    // panic!("Oops! Something went terribly wrong. Please restart the machine.");
+
+    #[cfg(test)]
+    test_main(); // Run tests conditionally in testing contexts
 
     loop {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn test_runner(tests: &[&dyn Fn()]) {
 #[test_case]
 fn trivial_assertion() {
     serial_print!("testing harness... ");
-    assert_eq!(1, 1);
+    assert_eq!(1, 0);
     serial_println!("[ok]");
 }
 
@@ -55,9 +55,18 @@ pub extern "C" fn _start() -> !{
     loop {}
 }
 
-
+#[cfg(not(test))] // Normal panic handler
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     println!("{}", info);
     loop {}
+}
+
+#[cfg(test)] // Test mode panic handler
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    serial_println!("[failed]\n");
+    serial_println!("Error: {}\n", info);
+    exit_qemu(QemuExitCode::Failure);
+    loop {} // Kept as compiler doesn't know we're causing a program exit
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,0 +1,36 @@
+use uart_16550::SerialPort;
+use spin::Mutex;
+use lazy_static::lazy_static;
+
+// We want to create a static writer instance (like with VGA) so that we can communicate via
+// UART
+lazy_static! {
+    pub static ref SERIAL1: Mutex<SerialPort> = {
+        let mut serial_port = unsafe { SerialPort::new(0x3F8) }; // First serial interface for UART
+        serial_port.init(); // We only want to instantiate a static writer once after all
+        Mutex::new(serial_port)
+    };
+}
+
+#[doc(hidden)]
+pub fn _print(args: ::core::fmt::Arguments) {
+    use core::fmt::Write;
+    SERIAL1.lock().write_fmt(args).expect("Printing to serial failed");
+}
+
+/// Print to the host system through the serial interface.
+#[macro_export]
+macro_rules! serial_print {
+    ($($arg:tt)*) => {
+        $crate::serial::_print(format_args!($($arg)*));
+    };
+}
+
+/// Print to the host system through the serial interface, appending a newline.
+#[macro_export]
+macro_rules! serial_println {
+    () => ($crate::serial_print!("\n"));
+    ($fmt:expr) => ($crate::serial_print!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => ($crate::serial_print!(
+        concat!($fmt, "\n"), $($arg)*));
+}

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -162,3 +162,26 @@ pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
     WRITER.lock().write_fmt(args).unwrap(); // Don't care about Result: writing to the VGA buffer is always Ok
 }
+
+#[test_case]
+fn test_println_simple() {
+    println!("test_println_simple output");
+}
+
+#[test_case]
+fn test_println_many() {
+    for _ in 0..200 {
+        println!("test_println_many output");
+    }
+}
+
+#[test_case]
+fn test_println_output() {
+    let s = "Some test string that fits on a single line";
+    println!("{}", s);
+
+    for (i, c) in s.chars().enumerate() {
+        let screen_char = WRITER.lock().buffer.chars[BUFFER_HEIGHT - 2][i].read();
+        assert_eq!(char::from(screen_char.ascii_character), c); // Verify that what's in the buffer is from our string
+    }
+}

--- a/tests/basic_boot.rs
+++ b/tests/basic_boot.rs
@@ -1,0 +1,24 @@
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(crate::test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+
+#[no_mangle] // each integration test is its own binary so we need to give it a start point (unmangled obviously)
+pub extern "C" fn _start() -> ! {
+    test_main();
+
+    loop {}
+}
+
+fn test_runner(tests: &[&dyn Fn()]) {
+    unimplemented!();
+}
+
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    loop {}
+}

--- a/tests/basic_boot.rs
+++ b/tests/basic_boot.rs
@@ -1,10 +1,11 @@
 #![no_std]
 #![no_main]
 #![feature(custom_test_frameworks)]
-#![test_runner(crate::test_runner)]
+#![test_runner(nugget::test_runner)]
 #![reexport_test_harness_main = "test_main"]
 
 use core::panic::PanicInfo;
+use nugget::println;
 
 #[no_mangle] // each integration test is its own binary so we need to give it a start point (unmangled obviously)
 pub extern "C" fn _start() -> ! {
@@ -13,12 +14,13 @@ pub extern "C" fn _start() -> ! {
     loop {}
 }
 
-fn test_runner(tests: &[&dyn Fn()]) {
-    unimplemented!();
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    nugget::test_panic_handler(info)
 }
 
 
-#[panic_handler]
-fn panic(info: &PanicInfo) -> ! {
-    loop {}
+#[test_case]
+fn test_println() {
+    println!("test_println output"); // verify that println works after booting
 }

--- a/tests/should_panic.rs
+++ b/tests/should_panic.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![no_main]
+
+#![feature(custom_test_frameworks)]
+#![test_runner(test_runner)]
+#![reexport_test_harness_main = "test_main"]
+
+use core::panic::PanicInfo;
+use nugget::{QemuExitCode, exit_qemu, serial_println, serial_print};
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    serial_println!("[ok]");
+    exit_qemu(QemuExitCode::Success);
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    should_fail();
+    serial_println!("[test did not panic]");
+    exit_qemu(QemuExitCode::Failure);
+
+    loop {}
+}
+
+fn should_fail() {
+    serial_print!("should_panic::should_fail...\t");
+    assert_eq!(0, 1);
+}


### PR DESCRIPTION
Introduce some basic unit and integration tests as well as a test harness and the ability to print out to serial over UART. This should allow simple development and testing from a host system using QEMU as we also handle QEMU exit codes while testing. Trivialise testing by developing a test runner and extricate shared functions into a kernel library.